### PR TITLE
fix: Refactor trailer fields statistics calculations to allow individual data record update

### DIFF
--- a/pkg/file/file_instance.go
+++ b/pkg/file/file_instance.go
@@ -91,44 +91,15 @@ func (f *fileInstance) GetDataRecords() []lib.Record {
 // GeneratorTrailer returns trailer segment that created automatically
 func (f *fileInstance) GeneratorTrailer() (lib.Record, error) {
 	var trailer lib.Record
-	var information *lib.TrailerInformation
 	var err error
 
 	if f.format == utils.PackedFileFormat {
-		trailer = lib.NewPackedTrailerRecord()
-		information, err = f.generatorPackedTrailer()
-		if err != nil {
-			return nil, err
-		}
+		trailer, err = f.generatorPackedTrailer()
 	} else {
-		trailer = lib.NewTrailerRecord()
-		information, err = f.generatorTrailer()
-		if err != nil {
-			return nil, err
-		}
+		trailer, err = f.generatorTrailer()
 	}
-
-	fromFields := reflect.ValueOf(information).Elem()
-	toFields := reflect.ValueOf(trailer).Elem()
-	for i := 0; i < fromFields.NumField(); i++ {
-		fieldName := fromFields.Type().Field(i).Name
-		fromField := fromFields.FieldByName(fieldName)
-		toField := toFields.FieldByName(fieldName)
-		if fromField.IsValid() && toField.CanSet() {
-			toField.Set(fromField)
-		}
-	}
-
-	if f.format == utils.PackedFileFormat {
-		if segment, ok := trailer.(*lib.PackedTrailerRecord); ok {
-			segment.RecordDescriptorWord = lib.PackedRecordLength
-			segment.RecordIdentifier = lib.TrailerIdentifier
-		}
-	} else {
-		if segment, ok := trailer.(*lib.TrailerRecord); ok {
-			segment.RecordDescriptorWord = lib.UnpackedRecordLength
-			segment.RecordIdentifier = lib.TrailerIdentifier
-		}
+	if err != nil {
+		return nil, err
 	}
 
 	return trailer, nil
@@ -159,20 +130,21 @@ func (f *fileInstance) Validate() error {
 		}
 	}
 
-	var information *lib.TrailerInformation
+	var fromFields reflect.Value
 	if f.format == utils.PackedFileFormat {
-		information, err = f.generatorPackedTrailer()
+		trailer, err := f.generatorPackedTrailer()
 		if err != nil {
 			return err
 		}
+		fromFields = reflect.ValueOf(trailer).Elem()
 	} else {
-		information, err = f.generatorTrailer()
+		trailer, err := f.generatorTrailer()
 		if err != nil {
 			return err
 		}
+		fromFields = reflect.ValueOf(trailer).Elem()
 	}
 
-	fromFields := reflect.ValueOf(information).Elem()
 	toFields := reflect.ValueOf(f.Trailer).Elem()
 	for i := 0; i < fromFields.NumField(); i++ {
 		fieldName := fromFields.Type().Field(i).Name
@@ -200,7 +172,6 @@ func (f *fileInstance) Validate() error {
 
 // Parse attempts to initialize a *File object assuming the input is valid raw data.
 func (f *fileInstance) Parse(record []byte, isVariableLength bool) error {
-
 	// remove new lines
 	record = slices.DeleteFunc(record, func(b byte) bool {
 		return b == '\r' || b == '\n'
@@ -487,356 +458,38 @@ func (f *fileInstance) SetType(newType string) error {
 	return nil
 }
 
-func (f *fileInstance) generatorTrailer() (*lib.TrailerInformation, error) {
-	trailer := &lib.TrailerInformation{}
+func (f *fileInstance) generatorTrailer() (*lib.TrailerRecord, error) {
+	trailer := &lib.TrailerRecord{
+		RecordDescriptorWord: lib.UnpackedRecordLength,
+		RecordIdentifier:     lib.TrailerIdentifier,
+		BlockCount:           2,
+	}
 
-	trailer.TotalBaseRecords = len(f.Bases)
-	trailer.BlockCount = len(f.Bases) + 2
 	for _, base := range f.Bases {
 		baseSegment, ok := base.(*lib.BaseSegment)
 		if !ok && baseSegment.Validate() != nil {
 			return nil, utils.NewErrInvalidSegment(baseSegment.Name())
 		}
-
-		if isValidSocialSecurityNumber(baseSegment.SocialSecurityNumber) {
-			trailer.TotalSocialNumbersAllSegments++
-			trailer.TotalSocialNumbersBaseSegments++
-		}
-
-		if !baseSegment.DateBirth.IsZero() {
-			trailer.TotalDatesBirthAllSegments++
-			trailer.TotalDatesBirthBaseSegments++
-		}
-
-		if baseSegment.ECOACode == lib.ECOACodeZ {
-			trailer.TotalECOACodeZ++
-		}
-		if baseSegment.TelephoneNumber > 0 {
-			trailer.TotalTelephoneNumbersAllSegments++
-		}
-		f.statisticAccountStatus(baseSegment.AccountStatus, trailer)
-		f.statisticBase(baseSegment, trailer)
+		trailer.TallyDataRecord(baseSegment)
 	}
 
 	return trailer, nil
 }
 
-func (f *fileInstance) generatorPackedTrailer() (*lib.TrailerInformation, error) {
-	trailer := &lib.TrailerInformation{}
-	trailer.TotalBaseRecords = len(f.Bases)
-	trailer.BlockCount = len(f.Bases) + 2
+func (f *fileInstance) generatorPackedTrailer() (*lib.PackedTrailerRecord, error) {
+	trailer := &lib.PackedTrailerRecord{
+		RecordDescriptorWord: lib.PackedRecordLength,
+		RecordIdentifier:     lib.TrailerIdentifier,
+		BlockCount:           2,
+	}
+
 	for _, base := range f.Bases {
 		base, ok := base.(*lib.PackedBaseSegment)
 		if !ok && base.Validate() != nil {
 			return nil, utils.NewErrInvalidSegment(base.Name())
 		}
-
-		if isValidSocialSecurityNumber(base.SocialSecurityNumber) {
-			trailer.TotalSocialNumbersAllSegments++
-			trailer.TotalSocialNumbersBaseSegments++
-		}
-
-		if !base.DateBirth.IsZero() {
-			trailer.TotalDatesBirthAllSegments++
-			trailer.TotalDatesBirthBaseSegments++
-		}
-
-		if base.ECOACode == lib.ECOACodeZ {
-			trailer.TotalECOACodeZ++
-		}
-
-		if base.TelephoneNumber > 0 {
-			trailer.TotalTelephoneNumbersAllSegments++
-		}
-
-		f.statisticAccountStatus(base.AccountStatus, trailer)
-		f.statisticPackedBase(base, trailer)
+		trailer.TallyDataRecord(base)
 	}
 
 	return trailer, nil
-}
-
-func (f *fileInstance) statisticAccountStatus(status string, info *lib.TrailerInformation) {
-	switch status {
-	case lib.AccountStatusDF:
-		info.TotalStatusCodeDF++
-	case lib.AccountStatusDA:
-		info.TotalStatusCodeDA++
-	case lib.AccountStatus05:
-		info.TotalStatusCode05++
-	case lib.AccountStatus11:
-		info.TotalStatusCode11++
-	case lib.AccountStatus13:
-		info.TotalStatusCode13++
-	case lib.AccountStatus61:
-		info.TotalStatusCode61++
-	case lib.AccountStatus62:
-		info.TotalStatusCode62++
-	case lib.AccountStatus63:
-		info.TotalStatusCode63++
-	case lib.AccountStatus64:
-		info.TotalStatusCode64++
-	case lib.AccountStatus65:
-		info.TotalStatusCode65++
-	case lib.AccountStatus71:
-		info.TotalStatusCode71++
-	case lib.AccountStatus78:
-		info.TotalStatusCode78++
-	case lib.AccountStatus80:
-		info.TotalStatusCode80++
-	case lib.AccountStatus82:
-		info.TotalStatusCode82++
-	case lib.AccountStatus83:
-		info.TotalStatusCode83++
-	case lib.AccountStatus84:
-		info.TotalStatusCode84++
-	case lib.AccountStatus88:
-		info.TotalStatusCode88++
-	case lib.AccountStatus89:
-		info.TotalStatusCode89++
-	case lib.AccountStatus93:
-		info.TotalStatusCode93++
-	case lib.AccountStatus94:
-		info.TotalStatusCode94++
-	case lib.AccountStatus95:
-		info.TotalStatusCode95++
-	case lib.AccountStatus96:
-		info.TotalStatusCode96++
-	case lib.AccountStatus97:
-		info.TotalStatusCode97++
-	}
-}
-
-func (f *fileInstance) statisticPackedBase(base *lib.PackedBaseSegment, trailer *lib.TrailerInformation) {
-	for _, j1 := range base.GetSegments(lib.J1SegmentName) {
-		sub, ok := j1.(*lib.J1Segment)
-		if !ok {
-			continue
-		}
-		if sub.ECOACode == lib.ECOACodeZ {
-			trailer.TotalECOACodeZ++
-		}
-		if sub.Validate() == nil {
-			trailer.TotalConsumerSegmentsJ1++
-
-			if isValidSocialSecurityNumber(sub.SocialSecurityNumber) {
-				trailer.TotalSocialNumbersAllSegments++
-				trailer.TotalSocialNumbersJ1Segments++
-			}
-
-			if !sub.DateBirth.IsZero() {
-				trailer.TotalDatesBirthAllSegments++
-				trailer.TotalDatesBirthJ1Segments++
-			}
-
-			if sub.TelephoneNumber > 0 {
-				trailer.TotalTelephoneNumbersAllSegments++
-			}
-		}
-	}
-	for _, j2 := range base.GetSegments(lib.J2SegmentName) {
-		sub, ok := j2.(*lib.J2Segment)
-		if !ok {
-			continue
-		}
-		if sub.ECOACode == lib.ECOACodeZ {
-			trailer.TotalECOACodeZ++
-		}
-		if sub.Validate() == nil {
-			trailer.TotalConsumerSegmentsJ2++
-
-			if isValidSocialSecurityNumber(sub.SocialSecurityNumber) {
-				trailer.TotalSocialNumbersAllSegments++
-				trailer.TotalSocialNumbersJ2Segments++
-			}
-
-			if !sub.DateBirth.IsZero() {
-				trailer.TotalDatesBirthAllSegments++
-				trailer.TotalDatesBirthJ2Segments++
-			}
-
-			if sub.TelephoneNumber > 0 {
-				trailer.TotalTelephoneNumbersAllSegments++
-			}
-		}
-	}
-	for _, k1 := range base.GetSegments(lib.K1SegmentName) {
-		sub, ok := k1.(*lib.K1Segment)
-		if !ok {
-			continue
-		}
-		if len(sub.OriginalCreditorName) > 0 {
-			trailer.TotalOriginalCreditorSegments++
-		}
-	}
-	for _, k2 := range base.GetSegments(lib.K2SegmentName) {
-		sub, ok := k2.(*lib.K2Segment)
-		if !ok {
-			continue
-		}
-		if sub.PurchasedIndicator == lib.PurchasedIndicatorToName ||
-			sub.PurchasedIndicator == lib.PurchasedIndicatorFromName {
-			trailer.TotalPurchasedToSegments++
-		}
-	}
-	for _, k3 := range base.GetSegments(lib.K3SegmentName) {
-		sub, ok := k3.(*lib.K3Segment)
-		if !ok {
-			continue
-		}
-		if sub.AgencyIdentifier == lib.AgencyIdentifierNotApplicable {
-			trailer.TotalMortgageInformationSegments++
-		}
-	}
-	for _, k4 := range base.GetSegments(lib.K4SegmentName) {
-		sub, ok := k4.(*lib.K4Segment)
-		if !ok {
-			continue
-		}
-		if sub.SpecializedPaymentIndicator == lib.SpecializedBalloonPayment ||
-			sub.SpecializedPaymentIndicator == lib.SpecializedDeferredPayment {
-			trailer.TotalPaymentInformationSegments++
-		}
-	}
-	for _, l1 := range base.GetSegments(lib.L1SegmentName) {
-		sub, ok := l1.(*lib.L1Segment)
-		if !ok {
-			continue
-		}
-		if sub.ChangeIndicator == lib.ChangeIndicatorAccountNumber ||
-			sub.ChangeIndicator == lib.ChangeIndicatorIdentificationNumber ||
-			sub.ChangeIndicator == lib.ChangeIndicatorBothNumber {
-			trailer.TotalChangeSegments++
-		}
-	}
-	for _, n1 := range base.GetSegments(lib.N1SegmentName) {
-		sub, ok := n1.(*lib.N1Segment)
-		if !ok {
-			continue
-		}
-		if len(sub.EmployerName) > 0 {
-			trailer.TotalEmploymentSegments++
-		}
-	}
-}
-
-func (f *fileInstance) statisticBase(base *lib.BaseSegment, trailer *lib.TrailerInformation) {
-	for _, j1 := range base.GetSegments(lib.J1SegmentName) {
-		sub, ok := j1.(*lib.J1Segment)
-		if !ok {
-			continue
-		}
-		if sub.ECOACode == lib.ECOACodeZ {
-			trailer.TotalECOACodeZ++
-		}
-		if sub.Validate() == nil {
-			trailer.TotalConsumerSegmentsJ1++
-
-			if isValidSocialSecurityNumber(sub.SocialSecurityNumber) {
-				trailer.TotalSocialNumbersAllSegments++
-				trailer.TotalSocialNumbersJ1Segments++
-			}
-
-			if !sub.DateBirth.IsZero() {
-				trailer.TotalDatesBirthAllSegments++
-				trailer.TotalDatesBirthJ1Segments++
-			}
-
-			if sub.TelephoneNumber > 0 {
-				trailer.TotalTelephoneNumbersAllSegments++
-			}
-		}
-	}
-	for _, j2 := range base.GetSegments(lib.J2SegmentName) {
-		sub, ok := j2.(*lib.J2Segment)
-		if !ok {
-			continue
-		}
-		if sub.ECOACode == lib.ECOACodeZ {
-			trailer.TotalECOACodeZ++
-		}
-		if sub.Validate() == nil {
-			trailer.TotalConsumerSegmentsJ2++
-
-			if isValidSocialSecurityNumber(sub.SocialSecurityNumber) {
-				trailer.TotalSocialNumbersAllSegments++
-				trailer.TotalSocialNumbersJ2Segments++
-			}
-
-			if !sub.DateBirth.IsZero() {
-				trailer.TotalDatesBirthAllSegments++
-				trailer.TotalDatesBirthJ2Segments++
-			}
-
-			if sub.TelephoneNumber > 0 {
-				trailer.TotalTelephoneNumbersAllSegments++
-			}
-		}
-	}
-	for _, k1 := range base.GetSegments(lib.K1SegmentName) {
-		sub, ok := k1.(*lib.K1Segment)
-		if !ok {
-			continue
-		}
-		if len(sub.OriginalCreditorName) > 0 {
-			trailer.TotalOriginalCreditorSegments++
-		}
-	}
-	for _, k2 := range base.GetSegments(lib.K2SegmentName) {
-		sub, ok := k2.(*lib.K2Segment)
-		if !ok {
-			continue
-		}
-		if sub.PurchasedIndicator == lib.PurchasedIndicatorToName ||
-			sub.PurchasedIndicator == lib.PurchasedIndicatorFromName {
-			trailer.TotalPurchasedToSegments++
-		}
-	}
-	for _, k3 := range base.GetSegments(lib.K3SegmentName) {
-		sub, ok := k3.(*lib.K3Segment)
-		if !ok {
-			continue
-		}
-		if sub.AgencyIdentifier == lib.AgencyIdentifierNotApplicable {
-			trailer.TotalMortgageInformationSegments++
-		}
-	}
-	for _, k4 := range base.GetSegments(lib.K4SegmentName) {
-		sub, ok := k4.(*lib.K4Segment)
-		if !ok {
-			continue
-		}
-		if sub.SpecializedPaymentIndicator == lib.SpecializedBalloonPayment ||
-			sub.SpecializedPaymentIndicator == lib.SpecializedDeferredPayment {
-			trailer.TotalPaymentInformationSegments++
-		}
-	}
-	for _, l1 := range base.GetSegments(lib.L1SegmentName) {
-		sub, ok := l1.(*lib.L1Segment)
-		if !ok {
-			continue
-		}
-		if sub.ChangeIndicator == lib.ChangeIndicatorAccountNumber ||
-			sub.ChangeIndicator == lib.ChangeIndicatorIdentificationNumber ||
-			sub.ChangeIndicator == lib.ChangeIndicatorBothNumber {
-			trailer.TotalChangeSegments++
-		}
-	}
-	for _, n1 := range base.GetSegments(lib.N1SegmentName) {
-		sub, ok := n1.(*lib.N1Segment)
-		if !ok {
-			continue
-		}
-		if len(sub.EmployerName) > 0 {
-			trailer.TotalEmploymentSegments++
-		}
-	}
-}
-
-func isValidSocialSecurityNumber(ssn int) bool {
-	// Do not count zero- or 9-filled SSNs.
-	if ssn <= 0 || ssn >= 999999999 {
-		return false
-	}
-	return true
 }

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -283,6 +284,142 @@ func (t *FileTest) TestGeneratorPackedTrailer(c *check.C) {
 	c.Assert(err, check.IsNil)
 	err = f.Validate()
 	c.Assert(err, check.IsNil)
+}
+
+func (t *FileTest) TestGeneratorTrailerStatistics(c *check.C) {
+	t.runTrailerTest(c, utils.CharacterFileFormat, &lib.BaseSegment{})
+}
+
+func (t *FileTest) TestGeneratorPackedTrailerStatistics(c *check.C) {
+	t.runTrailerTest(c, utils.PackedFileFormat, &lib.PackedBaseSegment{})
+}
+
+// allAccountStatusCases returns every account status code and the trailer field that should be 1.
+func allAccountStatusCases() []string {
+	return []string{
+		lib.AccountStatusDF,
+		lib.AccountStatusDA,
+		lib.AccountStatus05,
+		lib.AccountStatus11,
+		lib.AccountStatus13,
+		lib.AccountStatus61,
+		lib.AccountStatus62,
+		lib.AccountStatus63,
+		lib.AccountStatus64,
+		lib.AccountStatus65,
+		lib.AccountStatus71,
+		lib.AccountStatus78,
+		lib.AccountStatus80,
+		lib.AccountStatus82,
+		lib.AccountStatus83,
+		lib.AccountStatus84,
+		lib.AccountStatus88,
+		lib.AccountStatus89,
+		lib.AccountStatus93,
+		lib.AccountStatus94,
+		lib.AccountStatus95,
+		lib.AccountStatus96,
+		lib.AccountStatus97,
+	}
+}
+
+func (t *FileTest) TestGeneratorTrailerStatistics(c *check.C) {
+	t.runTrailerTest(c, utils.CharacterFileFormat, &lib.BaseSegment{})
+}
+
+func (t *FileTest) TestGeneratorPackedTrailerStatistics(c *check.C) {
+	t.runTrailerTest(c, utils.PackedFileFormat, &lib.PackedBaseSegment{})
+}
+
+// runTrailerTest is a helper function to test trailer generation for both character and packed file
+// formats using the same logic. It tests for correct counting of account status codes and segment
+// totals in the generated trailer.
+func (t *FileTest) runTrailerTest(c *check.C, format string, baseTemplate interface{}) {
+	f, err := os.Open(filepath.Join("..", "..", "test", "testdata", "trailer_statistics.json"))
+	c.Assert(err, check.IsNil)
+	defer f.Close()
+
+	file, err := NewFile(format)
+	c.Assert(err, check.IsNil)
+
+	base := reflect.New(reflect.TypeOf(baseTemplate).Elem()).Interface()
+	err = json.Unmarshal(utils.ReadFile(f), base) // <--- THIS WAS MISSING
+	c.Assert(err, check.IsNil)
+	baseVal := reflect.ValueOf(base).Elem()
+
+	statusesRequiringPaymentRating := map[string]bool{
+		lib.AccountStatus05: true, lib.AccountStatus13: true, lib.AccountStatus65: true,
+		lib.AccountStatus88: true, lib.AccountStatus89: true, lib.AccountStatus94: true, lib.AccountStatus95: true,
+	}
+
+	// create a base segment for each account status, with corresponding payment rating
+	accountStatuses := allAccountStatusCases()
+	for _, status := range accountStatuses {
+		baseCopyVal := reflect.New(baseVal.Type())
+		baseCopyVal.Elem().Set(baseVal)
+
+		v := baseCopyVal.Elem()
+
+		v.FieldByName("AccountStatus").SetString(status)
+
+		if statusesRequiringPaymentRating[status] {
+			v.FieldByName("PaymentRating").SetString(lib.PaymentRatingCurrent)
+		}
+
+		record := baseCopyVal.Interface().(lib.Record)
+		err = file.AddDataRecord(record)
+		c.Assert(err, check.IsNil)
+	}
+
+	tr, err := file.GeneratorTrailer()
+	c.Assert(err, check.IsNil)
+
+	t.assertTrailerFields(c, tr, len(accountStatuses))
+}
+
+func (t *FileTest) assertTrailerFields(c *check.C, trailer any, numSegments int) {
+	v := reflect.ValueOf(trailer).Elem()
+
+	checkField := func(fieldName string, expected int) {
+		field := v.FieldByName(fieldName)
+		if !field.IsValid() {
+			c.Fatalf("Field %s not found on trailer struct", fieldName)
+		}
+		actual := int(field.Int())
+		c.Check(actual, check.Equals, expected,
+			check.Commentf("Field %s: expected %d, got %d", fieldName, expected, actual))
+	}
+
+	accountStatusFields := []string{
+		"TotalStatusCodeDF", "TotalStatusCodeDA", "TotalStatusCode05", "TotalStatusCode11",
+		"TotalStatusCode13", "TotalStatusCode61", "TotalStatusCode62", "TotalStatusCode63",
+		"TotalStatusCode64", "TotalStatusCode65", "TotalStatusCode71", "TotalStatusCode78",
+		"TotalStatusCode80", "TotalStatusCode82", "TotalStatusCode83", "TotalStatusCode84",
+		"TotalStatusCode88", "TotalStatusCode89", "TotalStatusCode93", "TotalStatusCode94",
+		"TotalStatusCode95", "TotalStatusCode96", "TotalStatusCode97",
+	}
+	for _, f := range accountStatusFields {
+		checkField(f, 1)
+	}
+
+	segmentTotalFields := []string{
+		"TotalBaseRecords", "TotalConsumerSegmentsJ1", "TotalConsumerSegmentsJ2",
+		"TotalOriginalCreditorSegments", "TotalPurchasedToSegments",
+		"TotalMortgageInformationSegments", "TotalPaymentInformationSegments",
+		"TotalChangeSegments", "TotalEmploymentSegments", "TotalSocialNumbersBaseSegments",
+		"TotalSocialNumbersJ1Segments", "TotalSocialNumbersJ2Segments",
+		"TotalDatesBirthBaseSegments", "TotalDatesBirthJ1Segments", "TotalDatesBirthJ2Segments",
+	}
+	for _, f := range segmentTotalFields {
+		checkField(f, numSegments)
+	}
+
+	checkField("BlockCount", numSegments+2)
+
+	// check combined segment fields
+	checkField("TotalECOACodeZ", 3*numSegments)
+	checkField("TotalSocialNumbersAllSegments", 3*numSegments)
+	checkField("TotalTelephoneNumbersAllSegments", 3*numSegments)
 }
 
 func (t *FileTest) TestFileValidate(c *check.C) {

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -323,14 +323,6 @@ func allAccountStatusCases() []string {
 	}
 }
 
-func (t *FileTest) TestGeneratorTrailerStatistics(c *check.C) {
-	t.runTrailerTest(c, utils.CharacterFileFormat, &lib.BaseSegment{})
-}
-
-func (t *FileTest) TestGeneratorPackedTrailerStatistics(c *check.C) {
-	t.runTrailerTest(c, utils.PackedFileFormat, &lib.PackedBaseSegment{})
-}
-
 // runTrailerTest is a helper function to test trailer generation for both character and packed file
 // formats using the same logic. It tests for correct counting of account status codes and segment
 // totals in the generated trailer.
@@ -471,7 +463,6 @@ func (t *FileTest) TestNewFileFromReader(c *check.C) {
 }
 
 func (t *FileTest) TestCreateFileFailed(c *check.C) {
-
 	r1 := bytes.NewReader(t.packedRaw[8:])
 	c.Assert(r1, check.NotNil)
 

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -24,7 +24,6 @@ import (
 func TestFile__Crashers(t *testing.T) {
 	paths := readCrasherInputFilePaths(t)
 	for i := range paths {
-
 		f, err := os.Open(paths[i])
 		if err != nil {
 			t.Fatal(err)
@@ -73,7 +72,9 @@ func (t *FileTest) TestJsonWithUnpackedVariableBlocked(c *check.C) {
 	err = json.Unmarshal(t.unpackedVariableBlockedJson, f)
 	c.Assert(err, check.IsNil)
 
-	raw, err := os.ReadFile(filepath.Join("..", "..", "test", "testdata", "unpacked_variable_file.dat"))
+	raw, err := os.ReadFile(
+		filepath.Join("..", "..", "test", "testdata", "unpacked_variable_file.dat"),
+	)
 	c.Assert(err, check.IsNil)
 
 	rawStr := strings.ReplaceAll(string(raw), "\r\n", "\n")
@@ -412,6 +413,7 @@ func (t *FileTest) assertTrailerFields(c *check.C, trailer any, numSegments int)
 	checkField("TotalECOACodeZ", 3*numSegments)
 	checkField("TotalSocialNumbersAllSegments", 3*numSegments)
 	checkField("TotalTelephoneNumbersAllSegments", 3*numSegments)
+	checkField("TotalDatesBirthAllSegments", 3*numSegments)
 }
 
 func (t *FileTest) TestFileValidate(c *check.C) {

--- a/pkg/lib/trailer_record.go
+++ b/pkg/lib/trailer_record.go
@@ -19,7 +19,6 @@ var _ Segment = (*PackedTrailerRecord)(nil)
 
 // TrailerRecord holds the trailer record
 type TrailerRecord struct {
-
 	// Contains a value equal to the length of the physical record. This value includes the four bytes reserved for this field.
 	// If fixed-length records are being reported, the Trailer Record should be the same length as all the data records.
 	// The Trailer Record should be padded with blanks to fill the needed number of positions.
@@ -237,6 +236,200 @@ func (r *TrailerRecord) AddApplicableSegment(s Segment) error {
 	return utils.NewErrApplicableSegment("trailer record", s.Name())
 }
 
+// TallyDataRecord updates trailer record fields based on the provided base segment data
+func (r *TrailerRecord) TallyDataRecord(base *BaseSegment) {
+	r.TotalBaseRecords++
+	r.BlockCount++
+	if utils.IsValidSocialSecurityNumber(base.SocialSecurityNumber) {
+		r.TotalSocialNumbersAllSegments++
+		r.TotalSocialNumbersBaseSegments++
+	}
+
+	if !base.DateBirth.IsZero() {
+		r.TotalDatesBirthAllSegments++
+		r.TotalDatesBirthBaseSegments++
+	}
+
+	if base.ECOACode == ECOACodeZ {
+		r.TotalECOACodeZ++
+	}
+
+	if base.TelephoneNumber > 0 {
+		r.TotalTelephoneNumbersAllSegments++
+	}
+
+	r.tallyAccountStatus(base.AccountStatus)
+	r.tallySegments(base)
+}
+
+// tallyAccountStatus updates trailer record account status fields based on the provided account
+// status
+func (r *TrailerRecord) tallyAccountStatus(status string) {
+	switch status {
+	case AccountStatusDF:
+		r.TotalStatusCodeDF++
+	case AccountStatusDA:
+		r.TotalStatusCodeDA++
+	case AccountStatus05:
+		r.TotalStatusCode05++
+	case AccountStatus11:
+		r.TotalStatusCode11++
+	case AccountStatus13:
+		r.TotalStatusCode13++
+	case AccountStatus61:
+		r.TotalStatusCode61++
+	case AccountStatus62:
+		r.TotalStatusCode62++
+	case AccountStatus63:
+		r.TotalStatusCode63++
+	case AccountStatus64:
+		r.TotalStatusCode64++
+	case AccountStatus65:
+		r.TotalStatusCode65++
+	case AccountStatus71:
+		r.TotalStatusCode71++
+	case AccountStatus78:
+		r.TotalStatusCode78++
+	case AccountStatus80:
+		r.TotalStatusCode80++
+	case AccountStatus82:
+		r.TotalStatusCode82++
+	case AccountStatus83:
+		r.TotalStatusCode83++
+	case AccountStatus84:
+		r.TotalStatusCode84++
+	case AccountStatus88:
+		r.TotalStatusCode88++
+	case AccountStatus89:
+		r.TotalStatusCode89++
+	case AccountStatus93:
+		r.TotalStatusCode93++
+	case AccountStatus94:
+		r.TotalStatusCode94++
+	case AccountStatus95:
+		r.TotalStatusCode95++
+	case AccountStatus96:
+		r.TotalStatusCode96++
+	case AccountStatus97:
+		r.TotalStatusCode97++
+	}
+}
+
+// tallySegments updates trailer record segment fields based on the provided base segment and its
+// associated segments (J1, J2, K1, K2, K3, K4, L1, N1)
+func (r *TrailerRecord) tallySegments(base *BaseSegment) {
+	for _, j1 := range base.GetSegments(J1SegmentName) {
+		sub, ok := j1.(*J1Segment)
+		if !ok {
+			continue
+		}
+		if sub.ECOACode == ECOACodeZ {
+			r.TotalECOACodeZ++
+		}
+		if sub.Validate() == nil {
+			r.TotalConsumerSegmentsJ1++
+
+			if utils.IsValidSocialSecurityNumber(sub.SocialSecurityNumber) {
+				r.TotalSocialNumbersAllSegments++
+				r.TotalSocialNumbersJ1Segments++
+			}
+
+			if !sub.DateBirth.IsZero() {
+				r.TotalDatesBirthAllSegments++
+				r.TotalDatesBirthJ1Segments++
+			}
+
+			if sub.TelephoneNumber > 0 {
+				r.TotalTelephoneNumbersAllSegments++
+			}
+		}
+	}
+	for _, j2 := range base.GetSegments(J2SegmentName) {
+		sub, ok := j2.(*J2Segment)
+		if !ok {
+			continue
+		}
+		if sub.ECOACode == ECOACodeZ {
+			r.TotalECOACodeZ++
+		}
+		if sub.Validate() == nil {
+			r.TotalConsumerSegmentsJ2++
+
+			if utils.IsValidSocialSecurityNumber(sub.SocialSecurityNumber) {
+				r.TotalSocialNumbersAllSegments++
+				r.TotalSocialNumbersJ2Segments++
+			}
+
+			if !sub.DateBirth.IsZero() {
+				r.TotalDatesBirthAllSegments++
+				r.TotalDatesBirthJ2Segments++
+			}
+
+			if sub.TelephoneNumber > 0 {
+				r.TotalTelephoneNumbersAllSegments++
+			}
+		}
+	}
+	for _, k1 := range base.GetSegments(K1SegmentName) {
+		sub, ok := k1.(*K1Segment)
+		if !ok {
+			continue
+		}
+		if len(sub.OriginalCreditorName) > 0 {
+			r.TotalOriginalCreditorSegments++
+		}
+	}
+	for _, k2 := range base.GetSegments(K2SegmentName) {
+		sub, ok := k2.(*K2Segment)
+		if !ok {
+			continue
+		}
+		if sub.PurchasedIndicator == PurchasedIndicatorToName ||
+			sub.PurchasedIndicator == PurchasedIndicatorFromName {
+			r.TotalPurchasedToSegments++
+		}
+	}
+	for _, k3 := range base.GetSegments(K3SegmentName) {
+		sub, ok := k3.(*K3Segment)
+		if !ok {
+			continue
+		}
+		if sub.AgencyIdentifier == AgencyIdentifierNotApplicable {
+			r.TotalMortgageInformationSegments++
+		}
+	}
+	for _, k4 := range base.GetSegments(K4SegmentName) {
+		sub, ok := k4.(*K4Segment)
+		if !ok {
+			continue
+		}
+		if sub.SpecializedPaymentIndicator == SpecializedBalloonPayment ||
+			sub.SpecializedPaymentIndicator == SpecializedDeferredPayment {
+			r.TotalPaymentInformationSegments++
+		}
+	}
+	for _, l1 := range base.GetSegments(L1SegmentName) {
+		sub, ok := l1.(*L1Segment)
+		if !ok {
+			continue
+		}
+		if sub.ChangeIndicator == ChangeIndicatorAccountNumber ||
+			sub.ChangeIndicator == ChangeIndicatorIdentificationNumber ||
+			sub.ChangeIndicator == ChangeIndicatorBothNumber {
+			r.TotalChangeSegments++
+		}
+	}
+	for _, n1 := range base.GetSegments(N1SegmentName) {
+		sub, ok := n1.(*N1Segment)
+		if !ok {
+			continue
+		}
+		if len(sub.EmployerName) > 0 {
+			r.TotalEmploymentSegments++
+		}
+	}
+}
+
 // PackedTrailerRecord holds the packed trailer record
 type PackedTrailerRecord TrailerRecord
 
@@ -348,4 +541,198 @@ func (r *PackedTrailerRecord) GetSegments(string) []Segment {
 // AddApplicableSegment will add new applicable segment into record
 func (r *PackedTrailerRecord) AddApplicableSegment(s Segment) error {
 	return utils.NewErrApplicableSegment("packed header record", s.Name())
+}
+
+// TallyDataRecord updates trailer record fields based on the provided base segment data
+func (r *PackedTrailerRecord) TallyDataRecord(base *PackedBaseSegment) {
+	r.TotalBaseRecords++
+	r.BlockCount++
+	if utils.IsValidSocialSecurityNumber(base.SocialSecurityNumber) {
+		r.TotalSocialNumbersAllSegments++
+		r.TotalSocialNumbersBaseSegments++
+	}
+
+	if !base.DateBirth.IsZero() {
+		r.TotalDatesBirthAllSegments++
+		r.TotalDatesBirthBaseSegments++
+	}
+
+	if base.ECOACode == ECOACodeZ {
+		r.TotalECOACodeZ++
+	}
+
+	if base.TelephoneNumber > 0 {
+		r.TotalTelephoneNumbersAllSegments++
+	}
+
+	r.tallyAccountStatus(base.AccountStatus)
+	r.tallySegments(base)
+}
+
+// tallyAccountStatus updates trailer record account status fields based on the provided account
+// status
+func (r *PackedTrailerRecord) tallyAccountStatus(status string) {
+	switch status {
+	case AccountStatusDF:
+		r.TotalStatusCodeDF++
+	case AccountStatusDA:
+		r.TotalStatusCodeDA++
+	case AccountStatus05:
+		r.TotalStatusCode05++
+	case AccountStatus11:
+		r.TotalStatusCode11++
+	case AccountStatus13:
+		r.TotalStatusCode13++
+	case AccountStatus61:
+		r.TotalStatusCode61++
+	case AccountStatus62:
+		r.TotalStatusCode62++
+	case AccountStatus63:
+		r.TotalStatusCode63++
+	case AccountStatus64:
+		r.TotalStatusCode64++
+	case AccountStatus65:
+		r.TotalStatusCode65++
+	case AccountStatus71:
+		r.TotalStatusCode71++
+	case AccountStatus78:
+		r.TotalStatusCode78++
+	case AccountStatus80:
+		r.TotalStatusCode80++
+	case AccountStatus82:
+		r.TotalStatusCode82++
+	case AccountStatus83:
+		r.TotalStatusCode83++
+	case AccountStatus84:
+		r.TotalStatusCode84++
+	case AccountStatus88:
+		r.TotalStatusCode88++
+	case AccountStatus89:
+		r.TotalStatusCode89++
+	case AccountStatus93:
+		r.TotalStatusCode93++
+	case AccountStatus94:
+		r.TotalStatusCode94++
+	case AccountStatus95:
+		r.TotalStatusCode95++
+	case AccountStatus96:
+		r.TotalStatusCode96++
+	case AccountStatus97:
+		r.TotalStatusCode97++
+	}
+}
+
+// tallySegments updates trailer record segment fields based on the provided base segment and its
+// associated segments (J1, J2, K1, K2, K3, K4, L1, N1)
+func (r *PackedTrailerRecord) tallySegments(base *PackedBaseSegment) {
+	for _, j1 := range base.GetSegments(J1SegmentName) {
+		sub, ok := j1.(*J1Segment)
+		if !ok {
+			continue
+		}
+		if sub.ECOACode == ECOACodeZ {
+			r.TotalECOACodeZ++
+		}
+		if sub.Validate() == nil {
+			r.TotalConsumerSegmentsJ1++
+
+			if utils.IsValidSocialSecurityNumber(sub.SocialSecurityNumber) {
+				r.TotalSocialNumbersAllSegments++
+				r.TotalSocialNumbersJ1Segments++
+			}
+
+			if !sub.DateBirth.IsZero() {
+				r.TotalDatesBirthAllSegments++
+				r.TotalDatesBirthJ1Segments++
+			}
+
+			if sub.TelephoneNumber > 0 {
+				r.TotalTelephoneNumbersAllSegments++
+			}
+		}
+	}
+	for _, j2 := range base.GetSegments(J2SegmentName) {
+		sub, ok := j2.(*J2Segment)
+		if !ok {
+			continue
+		}
+		if sub.ECOACode == ECOACodeZ {
+			r.TotalECOACodeZ++
+		}
+		if sub.Validate() == nil {
+			r.TotalConsumerSegmentsJ2++
+
+			if utils.IsValidSocialSecurityNumber(sub.SocialSecurityNumber) {
+				r.TotalSocialNumbersAllSegments++
+				r.TotalSocialNumbersJ2Segments++
+			}
+
+			if !sub.DateBirth.IsZero() {
+				r.TotalDatesBirthAllSegments++
+				r.TotalDatesBirthJ2Segments++
+			}
+
+			if sub.TelephoneNumber > 0 {
+				r.TotalTelephoneNumbersAllSegments++
+			}
+		}
+	}
+	for _, k1 := range base.GetSegments(K1SegmentName) {
+		sub, ok := k1.(*K1Segment)
+		if !ok {
+			continue
+		}
+		if len(sub.OriginalCreditorName) > 0 {
+			r.TotalOriginalCreditorSegments++
+		}
+	}
+	for _, k2 := range base.GetSegments(K2SegmentName) {
+		sub, ok := k2.(*K2Segment)
+		if !ok {
+			continue
+		}
+		if sub.PurchasedIndicator == PurchasedIndicatorToName ||
+			sub.PurchasedIndicator == PurchasedIndicatorFromName {
+			r.TotalPurchasedToSegments++
+		}
+	}
+	for _, k3 := range base.GetSegments(K3SegmentName) {
+		sub, ok := k3.(*K3Segment)
+		if !ok {
+			continue
+		}
+		if sub.AgencyIdentifier == AgencyIdentifierNotApplicable {
+			r.TotalMortgageInformationSegments++
+		}
+	}
+	for _, k4 := range base.GetSegments(K4SegmentName) {
+		sub, ok := k4.(*K4Segment)
+		if !ok {
+			continue
+		}
+		if sub.SpecializedPaymentIndicator == SpecializedBalloonPayment ||
+			sub.SpecializedPaymentIndicator == SpecializedDeferredPayment {
+			r.TotalPaymentInformationSegments++
+		}
+	}
+	for _, l1 := range base.GetSegments(L1SegmentName) {
+		sub, ok := l1.(*L1Segment)
+		if !ok {
+			continue
+		}
+		if sub.ChangeIndicator == ChangeIndicatorAccountNumber ||
+			sub.ChangeIndicator == ChangeIndicatorIdentificationNumber ||
+			sub.ChangeIndicator == ChangeIndicatorBothNumber {
+			r.TotalChangeSegments++
+		}
+	}
+	for _, n1 := range base.GetSegments(N1SegmentName) {
+		sub, ok := n1.(*N1Segment)
+		if !ok {
+			continue
+		}
+		if len(sub.EmployerName) > 0 {
+			r.TotalEmploymentSegments++
+		}
+	}
 }

--- a/pkg/utils/validations.go
+++ b/pkg/utils/validations.go
@@ -1,0 +1,11 @@
+package utils
+
+// IsValidSocialSecurityNumber checks if the provided SSN is valid. It should be a 9-digit number
+// that is not all zeros or all nines.
+func IsValidSocialSecurityNumber(ssn int) bool {
+	// Do not count zero- or 9-filled SSNs.
+	if ssn <= 0 || ssn >= 999999999 {
+		return false
+	}
+	return true
+}

--- a/test/testdata/trailer_statistics.json
+++ b/test/testdata/trailer_statistics.json
@@ -1,0 +1,111 @@
+{
+  "base": {
+    "blockDescriptorWord": 1268,
+    "recordDescriptorWord": 1264,
+    "processingIndicator": 1,
+    "timeStamp": "2020-01-01T01:11:22Z",
+    "identificationNumber": "6666666",
+    "consumerAccountNumber": "553723456",
+    "portfolioType": "M",
+    "accountType": "48",
+    "dateOpened": "2019-11-22T00:00:00Z",
+    "highestCredit": 2438,
+    "termsDuration": "LOC",
+    "actualPaymentAmount": 100,
+    "accountStatus": "62",
+    "paymentHistoryProfile": "BBBBBBBBBBBBBBBBBBBBBBBB",
+    "specialComment": "AS",
+    "complianceConditionCode": "XA",
+    "currentBalance": 2233,
+    "dateAccountInformation": "2002-09-20T00:00:00Z",
+    "dateFirstDelinquency": "2001-07-19T00:00:00Z",
+    "dateClosed": "2002-08-02T00:00:00Z",
+    "dateLastPayment": "2002-08-02T00:00:00Z",
+    "interestTypeIndicator": "",
+    "surname": "SMITH-JONES",
+    "firstName": "JUNIOR",
+    "generationCode": "S",
+    "socialSecurityNumber": 159328759,
+    "dateBirth": "1972-03-18T00:00:00Z",
+    "telephoneNumber": 5175555555,
+    "ecoaCode": "Z",
+    "countryCode": "US",
+    "firstLineAddress": "RMXH+6W Casper, Wyoming,",
+    "secondLineAddress": "United States",
+    "city": "U.S. Postal",
+    "state": "MI",
+    "zipCode": "72654",
+    "addressIndicator": "Y",
+    "residenceCode": "O"
+  },
+  "j1": [
+    {
+      "segmentIdentifier": "J1",
+      "surname": "BEAUCHAMP",
+      "firstName": "KEVIN",
+      "generationCode": "S",
+      "socialSecurityNumber": 445112877,
+      "dateBirth": "2020-01-02T00:00:00Z",
+      "telephoneNumber": 4335552333,
+      "ecoaCode": "Z",
+      "consumerInformationIndicator": "R"
+    }
+  ],
+  "j2": [
+    {
+      "segmentIdentifier": "J2",
+      "surname": "BEAUCHAMP",
+      "firstName": "KEVIN",
+      "generationCode": "S",
+      "socialSecurityNumber": 445112877,
+      "dateBirth": "2020-01-02T00:00:00Z",
+      "telephoneNumber": 4335552333,
+      "ecoaCode": "Z",
+      "consumerInformationIndicator": "R",
+      "countryCode": "US",
+      "firstLineAddress": "234 HARRISON PLACE",
+      "secondLineAddress": "SUITE #305",
+      "city": "LANSING",
+      "state": "MI",
+      "zipCode": "72654",
+      "addressIndicator": "Y",
+      "residenceCode": "O"
+    }
+  ],
+  "k1": {
+    "segmentIdentifier": "K1",
+    "originalCreditorName": "WETCOSAT INDUSTRIES LTD.",
+    "creditorClassification": 4
+  },
+  "k2": {
+    "segmentIdentifier": "K2",
+    "purchasedIndicator": 1,
+    "purchasedName": "Purchased From Name"
+  },
+  "k3": {
+    "segmentIdentifier": "K3",
+    "mortgageIdentificationNumber": "Mortgage Number"
+  },
+  "k4": {
+    "segmentIdentifier": "K4",
+    "specializedPaymentIndicator": 1,
+    "deferredPaymentStartDate": "2020-01-20T00:00:00Z",
+    "balloonPaymentDueDate": "2020-01-20T00:00:00Z",
+    "balloonPaymentAmount": 1234
+  },
+  "l1": {
+    "segmentIdentifier": "L1",
+    "changeIndicator": 1,
+    "newConsumerAccountNumber": "New Consumer Account Number"
+  },
+  "n1": {
+    "segmentIdentifier": "N1",
+    "employerName": "Employer Name",
+    "firstLineEmployerAddress": "First Line of Employer Address",
+    "secondLineEmployerAddress": "Second Line of Employer Address",
+    "employerCity": "Employer City",
+    "employerState": "MI",
+    "zipCode": "23456",
+    "occupation": "Occupation"
+  }
+}


### PR DESCRIPTION
Refactor moov library to be able to update trailer record statistics with individual data record.
- Current approach to have `fileInstance` hold all processed data records, and then generate header, data record, and trailer segments result in high memory usage when there are millions of data records.
- Allowing data record segments to be written directly to disk, instead of adding them to `fileInstance`, reduces memory usage
    - This requires updating trailer segment statistics while individual data record is being processed  


AC:
- Add tests to `fileInstance.generatorTrailer()` and `fileInstance.generatorPackedTrailer()` that cover all trailer segment fields statistics (all account statuses and total segment fields calculations)
- Refactor `fileInstance.generatorTrailer()` and `fileInstance.generatorPackedTrailer()` and their related statistics method to `TrailerRecord.TallyDataRecord(*lib.BaseSegment) error` and `PackedTrailerRecord.TallyDataRecord(*lib.BaseSegment) error` to calculate trailer segment for each data record. 
    

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how trailer counts are computed for both packed and character formats, which can affect generated file correctness if any field is miscounted. Risk is mitigated by new tests covering all account status codes and segment-related totals.
> 
> **Overview**
> Refactors trailer generation so statistics are **tallied per data record** via new `TrailerRecord.TallyDataRecord` and `PackedTrailerRecord.TallyDataRecord`, removing the previous `fileInstance`-level statistics helpers and reflection-based field copying.
> 
> Adds a shared `utils.IsValidSocialSecurityNumber` helper and introduces new tests (plus `trailer_statistics.json`) to validate trailer counters across **all account status codes** and key segment totals for both packed and character formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc6b5688988687f3dc04bbe1ef9c41e410bb78bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->